### PR TITLE
Fix default avatar path

### DIFF
--- a/includes/classes/NotificationsRenderer.php
+++ b/includes/classes/NotificationsRenderer.php
@@ -27,7 +27,7 @@ class NotificationsRenderer
         } else {
             $actor = [
                 'display_name' => 'System',
-                'avatar' => '/assets/img/default-avatar.png'
+                'avatar' => '/assets/img/default_avatar.png'
             ];
         }
         $when = timeAgoShort($notification['created_at']);


### PR DESCRIPTION
## Summary
- correct the path to the default avatar in NotificationsRenderer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684151b208e48323bc956bfbb4e5ab5a